### PR TITLE
Implement OSShell, context, theme system, and public hooks

### DIFF
--- a/packages/next-os/src/components/OSShell/OSShell.tsx
+++ b/packages/next-os/src/components/OSShell/OSShell.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { AppDefinition, DeepPartial } from '../../types'
+import type { OSTheme } from '../../themes/types'
+import { macosTheme } from '../../themes/macos'
+import { mergeTheme } from '../../utils/mergeTheme'
+import { themeToVars } from '../../utils/themeVars'
+import { OSProvider } from '../../context/OSProvider'
+
+const builtInThemes: Record<string, OSTheme> = {
+  macos: macosTheme,
+}
+
+export interface OSShellProps {
+  apps: AppDefinition[]
+  theme?: 'macos' | 'windows11' | 'ubuntu' | OSTheme | DeepPartial<OSTheme>
+  wallpaper?: string
+  taskbarVariant?: 'dock' | 'taskbar'
+  initialWindows?: string[]
+  onWindowOpen?: (appId: string) => void
+  onWindowClose?: (windowId: string) => void
+  onWindowFocus?: (windowId: string) => void
+  children: React.ReactNode
+}
+
+function resolveTheme(
+  theme: OSShellProps['theme']
+): OSTheme {
+  if (!theme) return macosTheme
+
+  // String name → built-in theme
+  if (typeof theme === 'string') {
+    return builtInThemes[theme] ?? macosTheme
+  }
+
+  // Full theme object (has `name` field)
+  if ('name' in theme && theme.name && typeof theme.name === 'string') {
+    // Check if it's a complete theme by looking for required sections
+    if (
+      'windowChrome' in theme &&
+      'dock' in theme &&
+      'taskbar' in theme &&
+      'desktop' in theme &&
+      'animation' in theme &&
+      'tokens' in theme
+    ) {
+      return theme as OSTheme
+    }
+  }
+
+  // Partial theme → merge with macOS defaults
+  return mergeTheme(macosTheme, theme as DeepPartial<OSTheme>)
+}
+
+export function OSShell({
+  apps,
+  theme: themeProp,
+  wallpaper,
+  taskbarVariant = 'dock',
+  initialWindows,
+  onWindowOpen,
+  onWindowClose,
+  onWindowFocus,
+  children,
+}: OSShellProps) {
+  const theme = useMemo(() => resolveTheme(themeProp), [themeProp])
+  const cssVars = useMemo(() => themeToVars(theme), [theme])
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        overflow: 'hidden',
+        fontFamily: theme.tokens['font-family'] ?? 'system-ui, sans-serif',
+        ...cssVars,
+      }}
+    >
+      <OSProvider
+        apps={apps}
+        theme={theme}
+        taskbarVariant={taskbarVariant}
+        wallpaper={wallpaper}
+        initialWindows={initialWindows}
+        onWindowOpen={onWindowOpen}
+        onWindowClose={onWindowClose}
+        onWindowFocus={onWindowFocus}
+      >
+        {children}
+      </OSProvider>
+    </div>
+  )
+}

--- a/packages/next-os/src/components/OSShell/index.ts
+++ b/packages/next-os/src/components/OSShell/index.ts
@@ -1,0 +1,2 @@
+export { OSShell } from './OSShell'
+export type { OSShellProps } from './OSShell'

--- a/packages/next-os/src/context/OSContext.tsx
+++ b/packages/next-os/src/context/OSContext.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import type { AppDefinition } from '../types'
+import type { OSTheme } from '../themes/types'
+
+export interface OSContextValue {
+  apps: AppDefinition[]
+  theme: OSTheme
+  taskbarVariant: 'dock' | 'taskbar'
+  wallpaper?: string
+  onWindowOpen?: (appId: string) => void
+  onWindowClose?: (windowId: string) => void
+  onWindowFocus?: (windowId: string) => void
+}
+
+export const OSContext = createContext<OSContextValue | null>(null)
+
+export function useOSContext(): OSContextValue {
+  const ctx = useContext(OSContext)
+  if (!ctx) {
+    throw new Error('useOSContext must be used within an OSShell')
+  }
+  return ctx
+}

--- a/packages/next-os/src/context/OSProvider.tsx
+++ b/packages/next-os/src/context/OSProvider.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { OSContext, type OSContextValue } from './OSContext'
+import { useOSStore } from '../store/windowStore'
+
+interface OSProviderProps extends OSContextValue {
+  initialWindows?: string[]
+  children: React.ReactNode
+}
+
+export function OSProvider({
+  initialWindows,
+  children,
+  ...contextValue
+}: OSProviderProps) {
+  const openWindow = useOSStore((s) => s.openWindow)
+  const initialized = useRef(false)
+
+  useEffect(() => {
+    if (initialized.current || !initialWindows?.length) return
+    initialized.current = true
+
+    for (const appId of initialWindows) {
+      openWindow(appId, contextValue.apps)
+    }
+  }, [initialWindows, contextValue.apps, openWindow])
+
+  return (
+    <OSContext.Provider value={contextValue}>{children}</OSContext.Provider>
+  )
+}

--- a/packages/next-os/src/hooks/useFocus.ts
+++ b/packages/next-os/src/hooks/useFocus.ts
@@ -1,0 +1,19 @@
+'use client'
+
+import { useOSStore } from '../store/windowStore'
+
+export function useFocus() {
+  const windows = useOSStore((s) => s.windows)
+  const zStack = useOSStore((s) => s.zStack)
+
+  const focusedWindowId =
+    zStack.length > 0
+      ? [...zStack].reverse().find((id) => windows[id]?.isFocused) ?? null
+      : null
+
+  const focusedAppId = focusedWindowId
+    ? windows[focusedWindowId]?.appId ?? null
+    : null
+
+  return { focusedWindowId, focusedAppId }
+}

--- a/packages/next-os/src/hooks/useTheme.ts
+++ b/packages/next-os/src/hooks/useTheme.ts
@@ -1,0 +1,8 @@
+'use client'
+
+import { useOSContext } from '../context/OSContext'
+import type { OSTheme } from '../themes/types'
+
+export function useTheme(): OSTheme {
+  return useOSContext().theme
+}

--- a/packages/next-os/src/hooks/useWindow.ts
+++ b/packages/next-os/src/hooks/useWindow.ts
@@ -1,0 +1,39 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useOSStore } from '../store/windowStore'
+import { useOSContext } from '../context/OSContext'
+
+export function useWindow(appId?: string) {
+  const { apps } = useOSContext()
+  const store = useOSStore()
+
+  const openWindow = useCallback(
+    (id: string) => store.openWindow(id, apps),
+    [store, apps]
+  )
+
+  // Unscoped API
+  if (!appId) {
+    return {
+      openWindow,
+      closeWindow: store.closeWindow,
+      focusWindow: store.focusWindow,
+    }
+  }
+
+  // Scoped API
+  const windowEntry = Object.values(store.windows).find(
+    (w) => w.appId === appId
+  )
+
+  return {
+    open: () => openWindow(appId),
+    close: () => windowEntry && store.closeWindow(windowEntry.id),
+    minimize: () => windowEntry && store.minimizeWindow(windowEntry.id),
+    maximize: () => windowEntry && store.maximizeWindow(windowEntry.id),
+    restore: () => windowEntry && store.restoreWindow(windowEntry.id),
+    isOpen: !!windowEntry,
+    isFocused: windowEntry?.isFocused ?? false,
+  }
+}

--- a/packages/next-os/src/index.ts
+++ b/packages/next-os/src/index.ts
@@ -1,3 +1,25 @@
+// Components
+export { OSShell } from './components/OSShell'
+export type { OSShellProps } from './components/OSShell'
+
+// Hooks
+export { useWindow } from './hooks/useWindow'
+export { useFocus } from './hooks/useFocus'
+export { useTheme } from './hooks/useTheme'
+
+// Context
+export { useOSContext } from './context/OSContext'
+
+// Store
 export { useOSStore } from './store/windowStore'
 export type { WindowState, OSStore } from './store/windowStore'
+
+// Types
 export type { AppDefinition, DeepPartial } from './types'
+export type { OSTheme } from './themes/types'
+
+// Themes
+export { macosTheme } from './themes/macos'
+
+// Utilities
+export { mergeTheme } from './utils/mergeTheme'

--- a/packages/next-os/src/themes/macos.ts
+++ b/packages/next-os/src/themes/macos.ts
@@ -1,0 +1,75 @@
+import type { OSTheme } from './types'
+
+export const macosTheme: OSTheme = {
+  name: 'macos',
+
+  windowChrome: {
+    borderRadius: '10px',
+    titlebarHeight: 40,
+    titlebarBg: 'rgba(236, 236, 236, 0.85)',
+    titlebarBgUnfocused: 'rgba(246, 246, 246, 0.9)',
+    titlebarTextColor: '#1d1d1f',
+    controlStyle: 'traffic-lights',
+    controlsPosition: 'left',
+    shadow: '0 8px 30px rgba(0, 0, 0, 0.12)',
+    shadowFocused: '0 12px 40px rgba(0, 0, 0, 0.2)',
+    border: '1px solid rgba(0, 0, 0, 0.1)',
+    glassBg: 'rgba(255, 255, 255, 0.7)',
+    glassBlur: 'blur(20px)',
+  },
+
+  dock: {
+    position: 'bottom',
+    height: 72,
+    itemSize: 48,
+    gap: 4,
+    bg: 'rgba(255, 255, 255, 0.2)',
+    blur: 'blur(20px)',
+    borderRadius: '16px',
+    padding: '4px 8px',
+    magnification: true,
+    runningIndicatorColor: 'rgba(0, 0, 0, 0.5)',
+  },
+
+  taskbar: {
+    position: 'bottom',
+    height: 40,
+    bg: 'rgba(236, 236, 236, 0.85)',
+    blur: 'blur(20px)',
+    itemActiveBg: 'rgba(0, 0, 0, 0.08)',
+    textColor: '#1d1d1f',
+  },
+
+  desktop: {
+    iconSize: 64,
+    iconLabelColor: '#ffffff',
+    iconLabelShadow: '0 1px 3px rgba(0, 0, 0, 0.6)',
+    iconSelectedBg: 'rgba(0, 122, 255, 0.3)',
+    gridGap: 16,
+    gridPadding: '24px',
+  },
+
+  animation: {
+    windowOpen: {
+      initial: { opacity: 0, scale: 0.95 },
+      animate: { opacity: 1, scale: 1, transition: { duration: 0.12, ease: 'easeOut' } },
+    },
+    windowClose: {
+      exit: { opacity: 0, scale: 0.95, transition: { duration: 0.1, ease: 'easeIn' } },
+    },
+    windowMinimize: {
+      exit: { opacity: 0, scale: 0.5, y: 200, transition: { duration: 0.2 } },
+    },
+    dockBounce: {
+      animate: {
+        y: [0, -20, 0, -12, 0, -6, 0],
+        transition: { duration: 0.4, ease: 'easeInOut' },
+      },
+    },
+  },
+
+  tokens: {
+    'font-family': '-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "Helvetica Neue", sans-serif',
+    'accent-color': '#007aff',
+  },
+}

--- a/packages/next-os/src/themes/types.ts
+++ b/packages/next-os/src/themes/types.ts
@@ -1,0 +1,64 @@
+import type { Variants } from 'framer-motion'
+
+export interface WindowChromeTheme {
+  borderRadius: string
+  titlebarHeight: number
+  titlebarBg: string
+  titlebarBgUnfocused: string
+  titlebarTextColor: string
+  controlStyle: 'traffic-lights' | 'squares' | 'custom'
+  controlsPosition: 'left' | 'right'
+  shadow: string
+  shadowFocused: string
+  border: string
+  glassBg: string
+  glassBlur: string
+}
+
+export interface DockTheme {
+  position: 'bottom' | 'top'
+  height: number
+  itemSize: number
+  gap: number
+  bg: string
+  blur: string
+  borderRadius: string
+  padding: string
+  magnification: boolean
+  runningIndicatorColor: string
+}
+
+export interface TaskbarTheme {
+  position: 'bottom' | 'top'
+  height: number
+  bg: string
+  blur: string
+  itemActiveBg: string
+  textColor: string
+}
+
+export interface DesktopTheme {
+  iconSize: number
+  iconLabelColor: string
+  iconLabelShadow: string
+  iconSelectedBg: string
+  gridGap: number
+  gridPadding: string
+}
+
+export interface AnimationTheme {
+  windowOpen: Variants
+  windowClose: Variants
+  windowMinimize: Variants
+  dockBounce: Variants
+}
+
+export interface OSTheme {
+  name: string
+  windowChrome: WindowChromeTheme
+  dock: DockTheme
+  taskbar: TaskbarTheme
+  desktop: DesktopTheme
+  animation: AnimationTheme
+  tokens: Record<string, string>
+}

--- a/packages/next-os/src/utils/mergeTheme.ts
+++ b/packages/next-os/src/utils/mergeTheme.ts
@@ -1,0 +1,34 @@
+import type { DeepPartial } from '../types'
+import type { OSTheme } from '../themes/types'
+
+function isObject(val: unknown): val is Record<string, unknown> {
+  return val !== null && typeof val === 'object' && !Array.isArray(val)
+}
+
+function deepMerge(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>
+): Record<string, unknown> {
+  const result = { ...base }
+  for (const key of Object.keys(override)) {
+    const baseVal = base[key]
+    const overrideVal = override[key]
+
+    if (isObject(baseVal) && isObject(overrideVal)) {
+      result[key] = deepMerge(baseVal, overrideVal)
+    } else {
+      result[key] = overrideVal
+    }
+  }
+  return result
+}
+
+export function mergeTheme(
+  base: OSTheme,
+  override: DeepPartial<OSTheme>
+): OSTheme {
+  return deepMerge(
+    base as unknown as Record<string, unknown>,
+    override as Record<string, unknown>
+  ) as unknown as OSTheme
+}

--- a/packages/next-os/src/utils/themeVars.ts
+++ b/packages/next-os/src/utils/themeVars.ts
@@ -1,0 +1,49 @@
+import type { OSTheme } from '../themes/types'
+
+export function themeToVars(theme: OSTheme): Record<string, string> {
+  const vars: Record<string, string> = {}
+
+  // Window chrome
+  vars['--nos-window-radius'] = theme.windowChrome.borderRadius
+  vars['--nos-titlebar-height'] = `${theme.windowChrome.titlebarHeight}px`
+  vars['--nos-titlebar-bg'] = theme.windowChrome.titlebarBg
+  vars['--nos-titlebar-bg-unfocused'] = theme.windowChrome.titlebarBgUnfocused
+  vars['--nos-titlebar-text-color'] = theme.windowChrome.titlebarTextColor
+  vars['--nos-window-shadow'] = theme.windowChrome.shadow
+  vars['--nos-window-shadow-focused'] = theme.windowChrome.shadowFocused
+  vars['--nos-window-border'] = theme.windowChrome.border
+  vars['--nos-window-glass-bg'] = theme.windowChrome.glassBg
+  vars['--nos-window-glass-blur'] = theme.windowChrome.glassBlur
+
+  // Dock
+  vars['--nos-dock-height'] = `${theme.dock.height}px`
+  vars['--nos-dock-item-size'] = `${theme.dock.itemSize}px`
+  vars['--nos-dock-gap'] = `${theme.dock.gap}px`
+  vars['--nos-dock-bg'] = theme.dock.bg
+  vars['--nos-dock-blur'] = theme.dock.blur
+  vars['--nos-dock-radius'] = theme.dock.borderRadius
+  vars['--nos-dock-padding'] = theme.dock.padding
+  vars['--nos-dock-indicator-color'] = theme.dock.runningIndicatorColor
+
+  // Taskbar
+  vars['--nos-taskbar-height'] = `${theme.taskbar.height}px`
+  vars['--nos-taskbar-bg'] = theme.taskbar.bg
+  vars['--nos-taskbar-blur'] = theme.taskbar.blur
+  vars['--nos-taskbar-item-active-bg'] = theme.taskbar.itemActiveBg
+  vars['--nos-taskbar-text-color'] = theme.taskbar.textColor
+
+  // Desktop
+  vars['--nos-desktop-icon-size'] = `${theme.desktop.iconSize}px`
+  vars['--nos-desktop-icon-label-color'] = theme.desktop.iconLabelColor
+  vars['--nos-desktop-icon-label-shadow'] = theme.desktop.iconLabelShadow
+  vars['--nos-desktop-icon-selected-bg'] = theme.desktop.iconSelectedBg
+  vars['--nos-desktop-grid-gap'] = `${theme.desktop.gridGap}px`
+  vars['--nos-desktop-grid-padding'] = theme.desktop.gridPadding
+
+  // Custom tokens
+  for (const [key, value] of Object.entries(theme.tokens)) {
+    vars[`--nos-${key}`] = value
+  }
+
+  return vars
+}


### PR DESCRIPTION
## Summary

- **OSTheme types** — full interface covering windowChrome, dock, taskbar, desktop, animation, and custom tokens
- **macOS theme** — traffic-light controls, frosted glass, dock magnification, soft shadows
- **mergeTheme** — deep partial merge utility for consumer theme overrides
- **CSS variable injection** — all theme values exposed as `--nos-*` custom properties
- **OSContext/OSProvider** — React context with apps, theme, callbacks; opens `initialWindows` on mount
- **OSShell** — root component that resolves theme (string name, full object, or partial), injects CSS vars, wraps children in provider
- **Hooks** — `useWindow` (scoped/unscoped), `useFocus`, `useTheme`
- **Public exports** — all components, hooks, types, themes, and utilities exported from index.ts

Closes #4
Closes #5
Closes #7

## Test plan

- [ ] `pnpm --filter next-os build` passes
- [ ] `pnpm --filter next-os lint` passes
- [ ] `OSShell` with `theme="macos"` resolves to macOS theme
- [ ] Partial theme override deep-merges with macOS defaults
- [ ] CSS variables are injected on the root shell div
- [ ] `useWindow('appId')` returns scoped API with isOpen/isFocused
- [ ] `initialWindows` opens specified apps on mount